### PR TITLE
Add AGL app service injection and PAL abstraction

### DIFF
--- a/src/content/browser/renderer_host/render_process_host_impl.cc
+++ b/src/content/browser/renderer_host/render_process_host_impl.cc
@@ -275,6 +275,7 @@
 #if defined(USE_NEVA_APPRUNTIME)
 #include "content/public/common/content_neva_switches.h"
 #include "neva/pal_service/pal_service.h"
+#include "neva/pal_service/public/mojom/appservice.mojom.h"
 #include "neva/pal_service/public/mojom/memorymanager.mojom.h"
 #include "neva/pal_service/public/mojom/os_crypt.mojom.h"
 #include "neva/pal_service/public/mojom/sample.mojom.h"
@@ -2299,6 +2300,12 @@ void RenderProcessHostImpl::RegisterMojoInterfaces() {
   VLOG(1) << __func__;
 
 #if defined(USE_NEVA_APPRUNTIME)
+  AddUIThreadInterface(
+      registry.get(),
+      base::BindRepeating(
+          [](mojo::PendingReceiver<pal::mojom::AppService> receiver) {
+            pal::GetPalService().BindAppService(std::move(receiver));
+          }));
   AddUIThreadInterface(
       registry.get(),
       base::BindRepeating(

--- a/src/neva/BUILD.gn
+++ b/src/neva/BUILD.gn
@@ -48,6 +48,10 @@ config("config") {
     defines += [ "ENABLE_NETWORK_ERROR_PAGE_CONTROLLER_WEBAPI=1" ]
   }
 
+  if (enable_agl_appservice_webapi) {
+    defines += [ "ENABLE_AGL_APPSERVICE_WEBAPI=1" ]
+  }
+
   if (neva_dcheck_always_on) {
     defines += [ "NEVA_DCHECK_ALWAYS_ON=1" ]
   }

--- a/src/neva/app_runtime/webapp_injection_manager.cc
+++ b/src/neva/app_runtime/webapp_injection_manager.cc
@@ -43,6 +43,9 @@ std::set<std::string> allowed_injections = {
 #if defined(ENABLE_MEMORYMANAGER_WEBAPI)
     std::string(injections::webapi::kMemoryManager),
 #endif
+#if defined(ENABLE_AGL_APPSERVICE_WEBAPI)
+    std::string(injections::webapi::kAGLAppService),
+#endif
 };
 
 }  // namespace

--- a/src/neva/injection/public/common/webapi_names.cc
+++ b/src/neva/injection/public/common/webapi_names.cc
@@ -20,6 +20,7 @@ namespace injections {
 
 namespace webapi {
 
+const char kAGLAppService[] = "v8/agl_appservice";
 const char kBrowserControl[] = "v8/browser_control";
 const char kMemoryManager[] = "v8/memorymanager";
 const char kNetworkErrorPage[] = "v8/networkerrorpage";

--- a/src/neva/injection/public/common/webapi_names.h
+++ b/src/neva/injection/public/common/webapi_names.h
@@ -23,6 +23,7 @@ namespace injections {
 
 namespace webapi {
 
+COMPONENT_EXPORT(INJECTION) extern const char kAGLAppService[];
 COMPONENT_EXPORT(INJECTION) extern const char kBrowserControl[];
 COMPONENT_EXPORT(INJECTION) extern const char kMemoryManager[];
 COMPONENT_EXPORT(INJECTION) extern const char kNetworkErrorPage[];

--- a/src/neva/injection/public/renderer/BUILD.gn
+++ b/src/neva/injection/public/renderer/BUILD.gn
@@ -50,6 +50,13 @@ source_set("renderer") {
     ]
   }
 
+  if (enable_agl_appservice_webapi) {
+    sources += [
+      "agl_appservice_webapi.cc",
+      "agl_appservice_webapi.h",
+    ]
+  }
+
   if (is_webos) {
     sources += [
       "webossystem_webapi.cc",

--- a/src/neva/injection/public/renderer/agl_appservice_webapi.cc
+++ b/src/neva/injection/public/renderer/agl_appservice_webapi.cc
@@ -1,0 +1,32 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "neva/injection/public/renderer/agl_appservice_webapi.h"
+
+#include "neva/injection/renderer/agl_appservice/agl_appservice_injection.h"
+
+namespace injections {
+
+// static
+void AGLAppServiceWebAPI::Install(blink::WebLocalFrame* frame) {
+  AGLAppServiceInjection::Install(frame);
+}
+
+void AGLAppServiceWebAPI::Uninstall(blink::WebLocalFrame* frame) {
+  AGLAppServiceInjection::Uninstall(frame);
+}
+
+}  // namespace injections

--- a/src/neva/injection/public/renderer/agl_appservice_webapi.h
+++ b/src/neva/injection/public/renderer/agl_appservice_webapi.h
@@ -1,0 +1,36 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef NEVA_INJECTION_PUBLIC_RENDERER_AGL_APPSERVICE_WEBAPI_H_
+#define NEVA_INJECTION_PUBLIC_RENDERER_AGL_APPSERVICE_WEBAPI_H_
+
+#include "base/component_export.h"
+
+namespace blink {
+class WebLocalFrame;
+}  // namespace blink
+
+namespace injections {
+
+class COMPONENT_EXPORT(INJECTION) AGLAppServiceWebAPI {
+ public:
+  static void Install(blink::WebLocalFrame* frame);
+  static void Uninstall(blink::WebLocalFrame* frame);
+};
+
+}  // namespace injections
+
+#endif  // NEVA_INJECTION_PUBLIC_RENDERER_AGL_APPSERVICE_WEBAPI_H_

--- a/src/neva/injection/public/renderer/injection_install.cc
+++ b/src/neva/injection/public/renderer/injection_install.cc
@@ -40,6 +40,10 @@
 #include "neva/injection/public/renderer/memorymanager_webapi.h"
 #endif  // defined(ENABLE_MEMORYMANAGER_WEBAPI)
 
+#if defined(ENABLE_AGL_APPSERVICE_WEBAPI)
+#include "neva/injection/public/renderer/agl_appservice_webapi.h"
+#endif  // defined(ENABLE_AGL_APPSERVICE_WEBAPI)
+
 namespace injections {
 
 bool GetInjectionInstallAPI(const std::string& name, InstallAPI* api) {
@@ -86,6 +90,13 @@ bool GetInjectionInstallAPI(const std::string& name, InstallAPI* api) {
   if (name == webapi::kBrowserControl) {
     api->install_func = BrowserControlWebAPI::Install;
     api->uninstall_func = BrowserControlWebAPI::Uninstall;
+    return true;
+  }
+#endif
+#if defined(ENABLE_AGL_APPSERVICE_WEBAPI)
+  if (name == webapi::kAGLAppService) {
+    api->install_func = AGLAppServiceWebAPI::Install;
+    api->uninstall_func = AGLAppServiceWebAPI::Uninstall;
     return true;
   }
 #endif

--- a/src/neva/injection/renderer/BUILD.gn
+++ b/src/neva/injection/renderer/BUILD.gn
@@ -62,6 +62,13 @@ source_set("renderer") {
     ]
   }
 
+  if (enable_agl_appservice_webapi) {
+    sources += [
+      "agl_appservice/agl_appservice_injection.cc",
+      "agl_appservice/agl_appservice_injection.h",
+    ]
+  }
+
   if (is_webos) {
     libs = ["luna-service2"]
     configs += ["//build/config/linux:glib"]

--- a/src/neva/injection/renderer/agl_appservice/agl_appservice_injection.cc
+++ b/src/neva/injection/renderer/agl_appservice/agl_appservice_injection.cc
@@ -1,0 +1,187 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "neva/injection/renderer/agl_appservice/agl_appservice_injection.h"
+
+#include "base/bind.h"
+#include "base/macros.h"
+#include "gin/arguments.h"
+#include "gin/function_template.h"
+#include "gin/handle.h"
+#include "neva/pal_service/public/mojom/constants.mojom.h"
+#include "third_party/blink/public/common/thread_safe_browser_interface_broker_proxy.h"
+#include "third_party/blink/public/platform/platform.h"
+#include "third_party/blink/public/web/blink.h"
+#include "third_party/blink/public/web/web_local_frame.h"
+#include "third_party/blink/public/web/web_script_source.h"
+
+namespace injections {
+
+namespace {
+
+const char kNavigatorObjectName[] = "navigator";
+const char kAppServiceObjectName[] = "appService";
+const char kStartMethodName[] = "start";
+const char kGetApplicationsMethodName[] = "getApplications";
+
+// Returns true if |maybe| is both a value, and that value is true.
+inline bool IsTrue(v8::Maybe<bool> maybe) {
+  return maybe.IsJust() && maybe.FromJust();
+}
+
+}  // anonymous namespace
+
+gin::WrapperInfo AGLAppServiceInjection::kWrapperInfo = {
+    gin::kEmbedderNativeGin};
+
+AGLAppServiceInjection::AGLAppServiceInjection() {
+  blink::Platform::Current()->GetBrowserInterfaceBroker()->GetInterface(
+      remote_appservice_.BindNewPipeAndPassReceiver());
+}
+
+AGLAppServiceInjection::~AGLAppServiceInjection() = default;
+
+void AGLAppServiceInjection::Start(gin::Arguments* args) {
+  std::string application_id;
+  if (!args->GetNext(&application_id)) {
+    args->ThrowError();
+    return;
+  }
+  remote_appservice_->Start(application_id);
+}
+
+void AGLAppServiceInjection::GetApplications(gin::Arguments* args) {
+  bool only_graphical;
+  if (!args->GetNext(&only_graphical)) {
+    args->ThrowError();
+    return;
+  }
+  v8::Local<v8::Function> local_func;
+  if (!args->GetNext(&local_func)) {
+    args->ThrowError();
+    return;
+  }
+
+  auto callback_ptr = std::make_unique<v8::Persistent<v8::Function>>(
+      args->isolate(), local_func);
+
+  remote_appservice_->GetApplications(
+      only_graphical,
+      base::BindOnce(&AGLAppServiceInjection::OnGetApplicationsRespond,
+                     base::Unretained(this),
+                     base::Passed(std::move(callback_ptr))));
+}
+
+gin::ObjectTemplateBuilder AGLAppServiceInjection::GetObjectTemplateBuilder(
+    v8::Isolate* isolate) {
+  return gin::Wrappable<AGLAppServiceInjection>::GetObjectTemplateBuilder(
+             isolate)
+      .SetMethod(kStartMethodName, &AGLAppServiceInjection::Start)
+      .SetMethod(kGetApplicationsMethodName,
+                 &AGLAppServiceInjection::GetApplications);
+}
+
+void AGLAppServiceInjection::OnGetApplicationsRespond(
+    std::unique_ptr<v8::Persistent<v8::Function>> callback,
+    const std::string& app_list) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::Object> wrapper;
+  if (!GetWrapper(isolate).ToLocal(&wrapper)) {
+    LOG(ERROR) << __func__ << "(): can not get wrapper";
+    return;
+  }
+
+  v8::Local<v8::Context> context = wrapper->CreationContext();
+  v8::Context::Scope context_scope(context);
+  v8::Local<v8::Function> local_callback = callback->Get(isolate);
+
+  v8::MaybeLocal<v8::Value> maybe_json =
+      v8::JSON::Parse(context, gin::StringToV8(isolate, app_list));
+  v8::Local<v8::Value> json;
+  if (maybe_json.ToLocal(&json)) {
+    const int argc = 1;
+    v8::Local<v8::Value> argv[] = {json};
+    ALLOW_UNUSED_LOCAL(local_callback->Call(context, wrapper, argc, argv));
+  } else {
+    LOG(ERROR) << __func__ << "(): malformed JSON";
+  }
+}
+
+// static
+void AGLAppServiceInjection::Install(blink::WebLocalFrame* frame) {
+  v8::Isolate* isolate = blink::MainThreadIsolate();
+  v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::Context> context = frame->MainWorldScriptContext();
+  if (context.IsEmpty())
+    return;
+
+  v8::Local<v8::Object> global = context->Global();
+  v8::Context::Scope context_scope(context);
+
+  v8::Local<v8::String> navigator_name =
+      gin::StringToV8(isolate, kNavigatorObjectName);
+  v8::Local<v8::Object> navigator;
+  if (!gin::Converter<v8::Local<v8::Object>>::FromV8(
+          isolate, global->Get(context, navigator_name).ToLocalChecked(),
+          &navigator))
+    return;
+
+  if (IsTrue(navigator->Has(context,
+                            gin::StringToV8(isolate, kAppServiceObjectName))))
+    return;
+
+  v8::Local<v8::Object> app_service;
+  CreateAppServiceObject(isolate, navigator).ToLocal(&app_service);
+}
+
+void AGLAppServiceInjection::Uninstall(blink::WebLocalFrame* frame) {
+  v8::Isolate* isolate = blink::MainThreadIsolate();
+  v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::Context> context = frame->MainWorldScriptContext();
+  if (context.IsEmpty())
+    return;
+
+  v8::Local<v8::Object> global = context->Global();
+  v8::Context::Scope context_scope(context);
+
+  v8::Local<v8::String> navigator_name =
+      gin::StringToV8(isolate, kNavigatorObjectName);
+  v8::Local<v8::Object> navigator;
+  if (gin::Converter<v8::Local<v8::Object>>::FromV8(
+          isolate, global->Get(context, navigator_name).ToLocalChecked(),
+          &navigator)) {
+    v8::Local<v8::String> appservice_name =
+        gin::StringToV8(isolate, kAppServiceObjectName);
+    if (IsTrue(navigator->Has(context, appservice_name)))
+      ALLOW_UNUSED_LOCAL(navigator->Delete(context, appservice_name));
+  }
+}
+
+// static
+v8::MaybeLocal<v8::Object> AGLAppServiceInjection::CreateAppServiceObject(
+    v8::Isolate* isolate,
+    v8::Local<v8::Object> parent) {
+  gin::Handle<AGLAppServiceInjection> appservice =
+      gin::CreateHandle(isolate, new AGLAppServiceInjection());
+  parent
+      ->Set(isolate->GetCurrentContext(),
+            gin::StringToV8(isolate, kAppServiceObjectName), appservice.ToV8())
+      .Check();
+  return appservice->GetWrapper(isolate);
+}
+
+}  // namespace injections

--- a/src/neva/injection/renderer/agl_appservice/agl_appservice_injection.cc
+++ b/src/neva/injection/renderer/agl_appservice/agl_appservice_injection.cc
@@ -64,11 +64,13 @@ void AGLAppServiceInjection::Start(gin::Arguments* args) {
 }
 
 void AGLAppServiceInjection::GetApplications(gin::Arguments* args) {
-  bool only_graphical;
-  if (!args->GetNext(&only_graphical)) {
+  v8::Local<v8::Value> only_graphical_value;
+  if (!args->GetNext(&only_graphical_value) || only_graphical_value.IsEmpty()) {
     args->ThrowError();
     return;
   }
+  bool only_graphical = only_graphical_value->IsTrue();
+
   v8::Local<v8::Function> local_func;
   if (!args->GetNext(&local_func)) {
     args->ThrowError();

--- a/src/neva/injection/renderer/agl_appservice/agl_appservice_injection.h
+++ b/src/neva/injection/renderer/agl_appservice/agl_appservice_injection.h
@@ -1,0 +1,74 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef NEVA_INJECTION_RENDERER_AGL_APPSERVICE_AGL_APPSERVICE_INJECTION_H_
+#define NEVA_INJECTION_RENDERER_AGL_APPSERVICE_AGL_APPSERVICE_INJECTION_H_
+
+#include <string>
+
+#include "gin/object_template_builder.h"
+#include "gin/wrappable.h"
+#include "mojo/public/cpp/bindings/associated_receiver.h"
+#include "mojo/public/cpp/bindings/pending_associated_receiver.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "neva/pal_service/public/mojom/appservice.mojom.h"
+#include "v8/include/v8.h"
+
+namespace blink {
+class WebLocalFrame;
+}  // namespace blink
+
+namespace gin {
+class Arguments;
+}  // namespace gin
+
+namespace injections {
+
+class AGLAppServiceInjection : public gin::Wrappable<AGLAppServiceInjection> {
+ public:
+  static gin::WrapperInfo kWrapperInfo;
+  static void Install(blink::WebLocalFrame* frame);
+  static void Uninstall(blink::WebLocalFrame* frame);
+
+  AGLAppServiceInjection();
+  AGLAppServiceInjection(const AGLAppServiceInjection&) = delete;
+  AGLAppServiceInjection& operator=(const AGLAppServiceInjection&) = delete;
+  ~AGLAppServiceInjection() override;
+
+  // exposed methods
+
+  // Call function from platform. Return nothing
+  void Start(gin::Arguments* application_id);
+  void GetApplications(gin::Arguments* arguments);
+
+ private:
+  static v8::MaybeLocal<v8::Object> CreateAppServiceObject(
+      v8::Isolate* isolate,
+      v8::Local<v8::Object> global);
+
+  gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
+      v8::Isolate* isolate) final;
+
+  void OnGetApplicationsRespond(
+      std::unique_ptr<v8::Persistent<v8::Function>> callback,
+      const std::string& app_list);
+
+  mojo::Remote<pal::mojom::AppService> remote_appservice_;
+};
+
+}  // namespace injections
+
+#endif  // NEVA_INJECTION_RENDERER_AGL_APPSERVICE_AGL_APPSERVICE_INJECTION_H_

--- a/src/neva/neva.gni
+++ b/src/neva/neva.gni
@@ -102,4 +102,7 @@ declare_args() {
 
   # Support single window mode
   use_single_window_mode = is_webos || is_agl
+
+  # Enable AGL application service WEBAPI
+  enable_agl_appservice_webapi = is_agl
 }

--- a/src/neva/pal_service/BUILD.gn
+++ b/src/neva/pal_service/BUILD.gn
@@ -20,6 +20,9 @@ import("//services/service_manager/public/cpp/service_executable.gni")
 
 component("pal_service") {
   sources = [
+    "appservice.cc",
+    "appservice.h",
+    "appservice_delegate.h",
     "memorymanager.cc",
     "memorymanager.h",
     "memorymanager_delegate.h",
@@ -66,6 +69,8 @@ component("pal_service") {
     deps += [
       "//neva/pal_service/webos:pal_service_webos",
     ]
+  } else if (is_agl) {
+    deps += [ "//neva/pal_service/agl:pal_service_agl" ]
   } else {
     deps += [
       "//neva/pal_service/pc:pal_service_pc",

--- a/src/neva/pal_service/agl/BUILD.gn
+++ b/src/neva/pal_service/agl/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright 2019 LG Electronics, Inc.
+# Copyright 2022 LG Electronics, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,17 +14,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import("//mojo/public/tools/bindings/mojom.gni")
+import("//neva/neva.gni")
+import("//neva/pal_service/pal_service.gni")
 
-mojom("mojom") {
+source_set("pal_service_agl") {
   sources = [
-    "appservice.mojom",
-    "constants.mojom",
-    "memorymanager.mojom",
-    "network_error_page_controller.mojom",
-    "os_crypt.mojom",
-    "pal_service.mojom",
-    "sample.mojom",
-    "system_servicebridge.mojom",
+    "appservice_delegate_agl.cc",
+    "appservice_delegate_agl.h",
+    "pal_platform_factory_agl.cc",
+    "platform_system_delegate_agl.cc",
+    "platform_system_delegate_agl.h"
+  ]
+
+  defines = pal_service_defines
+
+  deps = [
+    "//base",
+    "//neva/pal_service/public/mojom",
   ]
 }

--- a/src/neva/pal_service/agl/BUILD.gn
+++ b/src/neva/pal_service/agl/BUILD.gn
@@ -14,8 +14,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import("//build/config/features.gni")
 import("//neva/neva.gni")
 import("//neva/pal_service/pal_service.gni")
+
+assert(use_dbus)
 
 source_set("pal_service_agl") {
   sources = [
@@ -30,6 +33,8 @@ source_set("pal_service_agl") {
 
   deps = [
     "//base",
+    "//dbus",
+    "//components/dbus/thread_linux",
     "//neva/pal_service/public/mojom",
   ]
 }

--- a/src/neva/pal_service/agl/appservice_delegate_agl.cc
+++ b/src/neva/pal_service/agl/appservice_delegate_agl.cc
@@ -16,24 +16,138 @@
 
 #include "neva/pal_service/agl/appservice_delegate_agl.h"
 
+#include "base/bind_helpers.h"
+#include "base/json/json_writer.h"
 #include "base/logging.h"
+#include "base/no_destructor.h"
+#include "base/values.h"
+#include "components/dbus/thread_linux/dbus_thread_linux.h"
+#include "dbus/bus.h"
+#include "dbus/message.h"
+#include "dbus/object_proxy.h"
+#include "dbus/values_util.h"
 
 namespace pal {
 namespace agl {
 
+namespace {
+
+const char kAutomotiveLinuxAppLaunchName[] = "org.automotivelinux.AppLaunch";
+const char kAutomotiveLinuxAppLaunchPath[] = "/org/automotivelinux/AppLaunch";
+const char kMethodStart[] = "start";
+const char kMethodListApplications[] = "listApplications";
 const char kDefaultGetApplicationsResponse[] = "{}";
+
+class AppLaunchHelper {
+ public:
+  using OnceResponse = base::OnceCallback<void(const std::string&)>;
+
+  AppLaunchHelper() = default;
+  AppLaunchHelper(const AppLaunchHelper&) = delete;
+  AppLaunchHelper& operator=(const AppLaunchHelper&) = delete;
+
+  static AppLaunchHelper& GetInstance() {
+    static base::NoDestructor<AppLaunchHelper> instance;
+    return *instance;
+  }
+
+  void Start(const std::string& application_id) {
+    EnsureProxy();
+
+    dbus::MethodCall method_call(kAutomotiveLinuxAppLaunchName, kMethodStart);
+    dbus::MessageWriter writer(&method_call);
+
+    writer.AppendString(application_id);
+
+    applaunch_proxy_->CallMethod(&method_call,
+                                 dbus::ObjectProxy::TIMEOUT_USE_DEFAULT,
+                                 base::DoNothing());
+  }
+
+  void GetApplications(bool only_graphical, OnceResponse callback) {
+    EnsureProxy();
+
+    dbus::MethodCall method_call(kAutomotiveLinuxAppLaunchName,
+                                 kMethodListApplications);
+    dbus::MessageWriter writer(&method_call);
+
+    writer.AppendBool(only_graphical);
+
+    applaunch_proxy_->CallMethod(
+        &method_call, dbus::ObjectProxy::TIMEOUT_USE_DEFAULT,
+        base::BindOnce(&AppLaunchHelper::OnListApplicationsResponse,
+                       weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+  }
+
+ private:
+  void EnsureProxy() {
+    if (!bus_) {
+      dbus::Bus::Options bus_options;
+      bus_options.bus_type = dbus::Bus::SESSION;
+      bus_options.connection_type = dbus::Bus::PRIVATE;
+      bus_options.dbus_task_runner = dbus_thread_linux::GetTaskRunner();
+      bus_ = base::MakeRefCounted<dbus::Bus>(bus_options);
+    }
+
+    if (!applaunch_proxy_) {
+      applaunch_proxy_ =
+          bus_->GetObjectProxy(kAutomotiveLinuxAppLaunchName,
+                               dbus::ObjectPath(kAutomotiveLinuxAppLaunchPath));
+    }
+  }
+
+  void ReturnEmptyListApplications(OnceResponse callback) {
+    std::move(callback).Run(kDefaultGetApplicationsResponse);
+  }
+
+  void OnListApplicationsResponse(OnceResponse callback,
+                                  dbus::Response* response) {
+    if (!response) {
+      LOG(ERROR) << __func__
+                 << " failed to get a DBus response from ListApplications";
+      ReturnEmptyListApplications(std::move(callback));
+      return;
+    }
+
+    dbus::MessageReader reader(response);
+    std::unique_ptr<base::Value> response_value = dbus::PopDataAsValue(&reader);
+    if (!response_value) {
+      LOG(ERROR) << __func__ << " failed to retrieve listApplications response";
+      ReturnEmptyListApplications(std::move(callback));
+      return;
+    }
+
+    std::string response_string;
+    if (!base::JSONWriter::Write(*response_value, &response_string)) {
+      LOG(ERROR) << __func__
+                 << " failed to generate the JSON string of the response";
+      ReturnEmptyListApplications(std::move(callback));
+      return;
+    }
+    std::move(callback).Run(response_string);
+  }
+
+  scoped_refptr<dbus::Bus> bus_;
+  dbus::ObjectProxy* applaunch_proxy_ = nullptr;
+
+  base::WeakPtrFactory<AppLaunchHelper> weak_ptr_factory_{this};
+};
+
+}  // namespace
 
 AppServiceDelegateAGL::AppServiceDelegateAGL() = default;
 AppServiceDelegateAGL::~AppServiceDelegateAGL() = default;
 
 void AppServiceDelegateAGL::Start(const std::string& application_id) {
-  LOG(ERROR) << __func__ << " application_id=" << application_id;
+  VLOG(1) << __func__ << " application_id=" << application_id;
+  AppLaunchHelper::GetInstance().Start(application_id);
 }
 
 void AppServiceDelegateAGL::GetApplications(bool graphical_only,
                                             OnceResponse callback) {
-  LOG(ERROR) << __func__ << " graphical_only=" << graphical_only;
-  std::move(callback).Run(kDefaultGetApplicationsResponse);
+  VLOG(1) << __func__ << " graphical_only=" << graphical_only;
+  AppLaunchHelper::GetInstance().GetApplications(graphical_only,
+                                                 std::move(callback));
 }
 
 }  // namespace agl

--- a/src/neva/pal_service/agl/appservice_delegate_agl.cc
+++ b/src/neva/pal_service/agl/appservice_delegate_agl.cc
@@ -1,0 +1,40 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "neva/pal_service/agl/appservice_delegate_agl.h"
+
+#include "base/logging.h"
+
+namespace pal {
+namespace agl {
+
+const char kDefaultGetApplicationsResponse[] = "{}";
+
+AppServiceDelegateAGL::AppServiceDelegateAGL() = default;
+AppServiceDelegateAGL::~AppServiceDelegateAGL() = default;
+
+void AppServiceDelegateAGL::Start(const std::string& application_id) {
+  LOG(ERROR) << __func__ << " application_id=" << application_id;
+}
+
+void AppServiceDelegateAGL::GetApplications(bool graphical_only,
+                                            OnceResponse callback) {
+  LOG(ERROR) << __func__ << " graphical_only=" << graphical_only;
+  std::move(callback).Run(kDefaultGetApplicationsResponse);
+}
+
+}  // namespace agl
+}  // namespace pal

--- a/src/neva/pal_service/agl/appservice_delegate_agl.h
+++ b/src/neva/pal_service/agl/appservice_delegate_agl.h
@@ -1,0 +1,43 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef NEVA_PAL_SERVICE_AGL_APPSERVICE_DELEGATE_AGL_H_
+#define NEVA_PAL_SERVICE_AGL_APPSERVICE_DELEGATE_AGL_H_
+
+#include "base/callback.h"
+#include "neva/pal_service/appservice_delegate.h"
+
+#include <memory>
+#include <string>
+
+namespace pal {
+namespace agl {
+
+class AppServiceDelegateAGL : public AppServiceDelegate {
+ public:
+  AppServiceDelegateAGL();
+  AppServiceDelegateAGL(const AppServiceDelegateAGL&) = delete;
+  AppServiceDelegateAGL& operator=(const AppServiceDelegateAGL&) = delete;
+  ~AppServiceDelegateAGL() override;
+
+  void Start(const std::string& application_id) override;
+  void GetApplications(bool graphical_only, OnceResponse callback) override;
+};
+
+}  // namespace agl
+}  // namespace pal
+
+#endif  // NEVA_PAL_SERVICE_AGL_MEMORYMANAGER_DELEGATE_AGL_H_

--- a/src/neva/pal_service/agl/pal_platform_factory_agl.cc
+++ b/src/neva/pal_service/agl/pal_platform_factory_agl.cc
@@ -1,4 +1,4 @@
-// Copyright 2019 LG Electronics, Inc.
+// Copyright 2022 LG Electronics, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@
 
 #include <memory>
 
-#include "neva/pal_service/appservice_delegate.h"
+#include "neva/pal_service/agl/appservice_delegate_agl.h"
+#include "neva/pal_service/agl/platform_system_delegate_agl.h"
 #include "neva/pal_service/memorymanager_delegate.h"
 #include "neva/pal_service/network_error_page_controller_delegate.h"
 #include "neva/pal_service/os_crypt_delegate.h"
-#include "neva/pal_service/pc/platform_system_delegate_pc.h"
 #include "neva/pal_service/system_servicebridge_delegate.h"
 
 namespace pal {
@@ -38,13 +38,14 @@ std::unique_ptr<OSCryptDelegate> PlatformFactory::CreateOSCryptDelegate() {
 
 std::unique_ptr<SystemServiceBridgeDelegate>
 PlatformFactory::CreateSystemServiceBridgeDelegate(
-  std::string, SystemServiceBridgeDelegate::Response) {
+    std::string,
+    SystemServiceBridgeDelegate::Response) {
   return std::unique_ptr<SystemServiceBridgeDelegate>();
 }
 
 std::unique_ptr<PlatformSystemDelegate>
 PlatformFactory::CreatePlatformSystemDelegate() {
-  return std::make_unique<pc::PlatformSystemDelegatePC>();
+  return std::make_unique<agl::PlatformSystemDelegateAGL>();
 }
 
 std::unique_ptr<NetworkErrorPageControllerDelegate>
@@ -54,7 +55,7 @@ PlatformFactory::CreateNetworkErrorPageControllerDelegate() {
 
 std::unique_ptr<AppServiceDelegate>
 PlatformFactory::CreateAppServiceDelegate() {
-  return std::unique_ptr<AppServiceDelegate>();
+  return std::make_unique<agl::AppServiceDelegateAGL>();
 }
 
 }  // namespace pal

--- a/src/neva/pal_service/agl/platform_system_delegate_agl.cc
+++ b/src/neva/pal_service/agl/platform_system_delegate_agl.cc
@@ -1,0 +1,75 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "neva/pal_service/agl/platform_system_delegate_agl.h"
+
+#include "base/files/file_util.h"
+#include "base/json/json_reader.h"
+#include "base/json/json_writer.h"
+#include "base/logging.h"
+
+namespace pal {
+
+namespace agl {
+
+PlatformSystemDelegateAGL::PlatformSystemDelegateAGL() = default;
+
+PlatformSystemDelegateAGL::~PlatformSystemDelegateAGL() = default;
+
+void PlatformSystemDelegateAGL::Initialize() {}
+
+std::string PlatformSystemDelegateAGL::GetCountry() const {
+  return std::string("{}");
+}
+
+std::string PlatformSystemDelegateAGL::GetDeviceInfoJSON() const {
+  return std::string("{}");
+}
+
+int PlatformSystemDelegateAGL::GetScreenWidth() const {
+  return 0;
+}
+
+int PlatformSystemDelegateAGL::GetScreenHeight() const {
+  return 0;
+}
+
+std::string PlatformSystemDelegateAGL::GetLocale() const {
+  return std::string();
+}
+
+std::string PlatformSystemDelegateAGL::GetLocaleRegion() const {
+  return std::string("US");
+}
+
+std::string PlatformSystemDelegateAGL::GetResource(
+    const std::string& path) const {
+  std::string file_str;
+  base::ReadFileToString(base::FilePath(path), &file_str);
+  return file_str;
+}
+
+bool PlatformSystemDelegateAGL::IsMinimal() const {
+  return false;
+}
+
+bool PlatformSystemDelegateAGL::GetHightContrast() const {
+  return false;
+}
+
+}  // namespace agl
+
+}  // namespace pal

--- a/src/neva/pal_service/agl/platform_system_delegate_agl.h
+++ b/src/neva/pal_service/agl/platform_system_delegate_agl.h
@@ -1,0 +1,51 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef NEVA_PAL_SERVICE_AGL_PLATFORM_SYSTEM_DELEGATE_AGL_H_
+#define NEVA_PAL_SERVICE_AGL_PLATFORM_SYSTEM_DELEGATE_AGL_H_
+
+#include "neva/pal_service/platform_system_delegate.h"
+
+namespace pal {
+
+namespace agl {
+
+class PlatformSystemDelegateAGL : public PlatformSystemDelegate {
+ public:
+  PlatformSystemDelegateAGL();
+  ~PlatformSystemDelegateAGL() override;
+
+  PlatformSystemDelegateAGL(const PlatformSystemDelegateAGL&) = delete;
+  PlatformSystemDelegateAGL& operator=(const PlatformSystemDelegateAGL&) =
+      delete;
+
+  void Initialize() override;
+  std::string GetCountry() const override;
+  std::string GetDeviceInfoJSON() const override;
+  int GetScreenWidth() const override;
+  int GetScreenHeight() const override;
+  std::string GetLocale() const override;
+  std::string GetLocaleRegion() const override;
+  std::string GetResource(const std::string& path) const override;
+  bool IsMinimal() const override;
+  bool GetHightContrast() const override;
+};
+
+}  // namespace agl
+
+}  // namespace pal
+
+#endif  // NEVA_PAL_SERVICE_AGL_PLATFORM_SYSTEM_DELEGATE_AGL_H_

--- a/src/neva/pal_service/appservice.cc
+++ b/src/neva/pal_service/appservice.cc
@@ -1,0 +1,49 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "neva/pal_service/appservice.h"
+
+#include "base/memory/weak_ptr.h"
+#include "neva/pal_service/appservice_delegate.h"
+#include "neva/pal_service/pal_platform_factory.h"
+
+namespace pal {
+
+AppServiceImpl::AppServiceImpl()
+    : delegate_(PlatformFactory::Get()->CreateAppServiceDelegate()),
+      weak_factory_(this) {}
+
+AppServiceImpl::~AppServiceImpl() = default;
+
+void AppServiceImpl::AddBinding(
+    mojo::PendingReceiver<mojom::AppService> receiver) {
+  receivers_.Add(this, std::move(receiver));
+}
+
+void AppServiceImpl::GetApplications(bool only_graphical,
+                                     GetApplicationsCallback callback) {
+  if (delegate_)
+    delegate_->GetApplications(only_graphical, std::move(callback));
+  else
+    std::move(callback).Run("{}");
+}
+
+void AppServiceImpl::Start(const std::string& application_id) {
+  if (delegate_)
+    delegate_->Start(application_id);
+}
+
+}  // namespace pal

--- a/src/neva/pal_service/appservice.h
+++ b/src/neva/pal_service/appservice.h
@@ -1,0 +1,51 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef NEVA_PAL_SERVICE_APPSERVICE_H_
+#define NEVA_PAL_SERVICE_APPSERVICE_H_
+
+#include "base/callback.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "mojo/public/cpp/bindings/remote_set.h"
+#include "neva/pal_service/public/mojom/appservice.mojom.h"
+
+namespace pal {
+
+class AppServiceDelegate;
+
+class AppServiceImpl : public mojom::AppService {
+ public:
+  AppServiceImpl();
+  AppServiceImpl(const AppServiceImpl&) = delete;
+  AppServiceImpl& operator=(const AppServiceImpl&) = delete;
+  ~AppServiceImpl() override;
+
+  void AddBinding(mojo::PendingReceiver<mojom::AppService> receiver);
+
+  // mojom::AppService
+  void Start(const std::string& application_id) override;
+  void GetApplications(bool graphical_only,
+                       GetApplicationsCallback callback) override;
+
+ private:
+  std::unique_ptr<AppServiceDelegate> delegate_;
+  mojo::ReceiverSet<mojom::AppService> receivers_;
+  base::WeakPtrFactory<AppServiceImpl> weak_factory_;
+};
+
+}  // namespace pal
+
+#endif  // NEVA_PAL_SERVICE_APPSERVICE_H_

--- a/src/neva/pal_service/appservice_delegate.h
+++ b/src/neva/pal_service/appservice_delegate.h
@@ -1,0 +1,36 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef NEVA_PAL_SERVICE_APPSERVICE_DELEGATE_H_
+#define NEVA_PAL_SERVICE_APPSERVICE_DELEGATE_H_
+
+#include <string>
+#include "base/callback.h"
+
+namespace pal {
+
+class AppServiceDelegate {
+ public:
+  virtual ~AppServiceDelegate() {}
+
+  using OnceResponse = base::OnceCallback<void(const std::string&)>;
+  virtual void Start(const std::string& application_id) = 0;
+  virtual void GetApplications(bool graphical_only, OnceResponse callback) = 0;
+};
+
+}  // namespace pal
+
+#endif  // NEVA_PAL_SERVICE_MEMORYMANAGER_DELEGATE_H_

--- a/src/neva/pal_service/pal_platform_factory.h
+++ b/src/neva/pal_service/pal_platform_factory.h
@@ -24,6 +24,7 @@
 
 namespace pal {
 
+class AppServiceDelegate;
 class MemoryManagerDelegate;
 class NetworkErrorPageControllerDelegate;
 class OSCryptDelegate;
@@ -32,6 +33,8 @@ class PlatformSystemDelegate;
 class COMPONENT_EXPORT(PAL_SERVICE) PlatformFactory {
  public:
   static PlatformFactory* Get();
+
+  std::unique_ptr<AppServiceDelegate> CreateAppServiceDelegate();
 
   std::unique_ptr<MemoryManagerDelegate> CreateMemoryManagerDelegate();
 

--- a/src/neva/pal_service/pal_service.cc
+++ b/src/neva/pal_service/pal_service.cc
@@ -29,8 +29,10 @@
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "mojo/public/cpp/bindings/receiver.h"
+#include "neva/pal_service/appservice.h"
 #include "neva/pal_service/memorymanager.h"
 #include "neva/pal_service/network_error_page_controller.h"
+#include "neva/pal_service/public/mojom/appservice.mojom.h"
 #include "neva/pal_service/public/mojom/memorymanager.mojom.h"
 #include "neva/pal_service/public/mojom/network_error_page_controller.mojom.h"
 #include "neva/pal_service/public/mojom/sample.mojom.h"
@@ -46,6 +48,8 @@ class PalServiceImpl : public mojom::PalService {
   ~PalServiceImpl() override;
 
  private:
+  void BindAppService(
+      mojo::PendingReceiver<mojom::AppService> receiver) override;
   void BindMemoryManager(
       mojo::PendingReceiver<mojom::MemoryManager> receiver) override;
   void BindNetworkErrorPageController(
@@ -56,6 +60,7 @@ class PalServiceImpl : public mojom::PalService {
       mojo::PendingReceiver<mojom::SystemServiceBridgeProvider>
           receiver) override;
 
+  std::unique_ptr<pal::AppServiceImpl> appservice_impl_;
   std::unique_ptr<pal::MemoryManagerImpl> memorymanager_impl_;
   std::unique_ptr<pal::NetworkErrorPageControllerImpl>
       network_error_page_controller_impl_;
@@ -72,6 +77,13 @@ PalServiceImpl::PalServiceImpl(
 }
 
 PalServiceImpl::~PalServiceImpl() {
+}
+
+void PalServiceImpl::BindAppService(
+    mojo::PendingReceiver<mojom::AppService> receiver) {
+  if (!appservice_impl_)
+    appservice_impl_ = std::make_unique<AppServiceImpl>();
+  appservice_impl_->AddBinding(std::move(receiver));
 }
 
 void PalServiceImpl::BindMemoryManager(

--- a/src/neva/pal_service/public/mojom/appservice.mojom
+++ b/src/neva/pal_service/public/mojom/appservice.mojom
@@ -1,0 +1,22 @@
+// Copyright 2022 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+module pal.mojom;
+
+interface AppService {
+  Start(string application_id);
+  GetApplications(bool only_graphical) => (string apps_list);
+};

--- a/src/neva/pal_service/public/mojom/pal_service.mojom
+++ b/src/neva/pal_service/public/mojom/pal_service.mojom
@@ -16,12 +16,14 @@
 
 module pal.mojom;
 
+import "neva/pal_service/public/mojom/appservice.mojom";
 import "neva/pal_service/public/mojom/memorymanager.mojom";
 import "neva/pal_service/public/mojom/network_error_page_controller.mojom";
 import "neva/pal_service/public/mojom/sample.mojom";
 import "neva/pal_service/public/mojom/system_servicebridge.mojom";
 
 interface PalService {
+  BindAppService(pending_receiver<AppService> receiver);
   BindMemoryManager(pending_receiver<MemoryManager> receiver);
   BindNetworkErrorPageController(
       pending_receiver<NetworkErrorPageController> receiver);

--- a/src/neva/pal_service/webos/pal_platform_factory_webos.cc
+++ b/src/neva/pal_service/webos/pal_platform_factory_webos.cc
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "neva/pal_service/appservice_delegate.h"
 #include "neva/pal_service/os_crypt_delegate.h"
 #include "neva/pal_service/webos/memorymanager_delegate_webos.h"
 #include "neva/pal_service/webos/network_error_page_controller_delegate_webos.h"
@@ -60,6 +61,11 @@ PlatformFactory::CreatePlatformSystemDelegate() {
 std::unique_ptr<NetworkErrorPageControllerDelegate>
 PlatformFactory::CreateNetworkErrorPageControllerDelegate() {
   return std::make_unique<webos::NetworkErrorPageControllerDelegateWebOS>();
+}
+
+std::unique_ptr<AppServiceDelegate>
+PlatformFactory::CreateAppServiceDelegate() {
+  return std::unique_ptr<AppServiceDelegate>();
 }
 
 }  // namespace pal


### PR DESCRIPTION
Introduce first WAM Chromium JS injection, appservice, that allows to retrieve the list of applications installed, and launch one of them. It also adds a new PAL service abstraction named appservice, with a D-Bus implementation for AGL applaunchd service.