### PR TITLE
[op][n_upsable][build] Fix build because of returning to base::Option…

### DIFF
--- a/src/net/dns/dns_query.cc
+++ b/src/net/dns/dns_query.cc
@@ -85,7 +85,7 @@ base::Optional<OptRecordRdata> AddPaddingIfNecessary(
         std::string(padding_size - OptRecordRdata::Opt::kHeaderSize, 0)));
   }
 
-  return merged_opt_rdata;
+  return std::move(merged_opt_rdata);
 }
 
 }  // namespace


### PR DESCRIPTION
…al without move

Certain versions of GCC cannot resolve automatically returning to a
base::Optional from the contained type. This was breaking sandboxed
build of dns_query.cc.

Bug-AGL: SPEC-4260