### PR TITLE
[op][n_upsable][wayland] Fix initialization of drag data controller

### DIFF
--- a/src/ui/ozone/platform/wayland/host/wayland_connection.cc
+++ b/src/ui/ozone/platform/wayland/host/wayland_connection.cc
@@ -391,8 +391,8 @@ void WaylandConnection::Global(void* data,
       return;
     }
     wl_seat_add_listener(connection->seat_.get(), &seat_listener, connection);
-    connection->CreateDataObjectsIfReady();
 #endif  // !defined(USE_NEVA_APPRUNTIME)
+    connection->CreateDataObjectsIfReady();
   } else if (!connection->shell_v6_ &&
              strcmp(interface, "zxdg_shell_v6") == 0) {
     // Check for zxdg_shell_v6 first.

--- a/src/ui/ozone/platform/wayland/host/wayland_toplevel_window.cc
+++ b/src/ui/ozone/platform/wayland/host/wayland_toplevel_window.cc
@@ -113,6 +113,7 @@ bool WaylandToplevelWindow::StartDrag(const ui::OSExchangeData& data,
                                       WmDragHandler::Delegate* delegate) {
   DCHECK(!drag_handler_delegate_);
   drag_handler_delegate_ = delegate;
+  DCHECK(connection()->data_drag_controller());
   connection()->data_drag_controller()->StartSession(data, operation);
 
   base::RunLoop drag_loop(base::RunLoop::Type::kNestableTasksAllowed);


### PR DESCRIPTION
The code path for processing wl_seat calls in NEVA app runtime was
missing the code to set up the drag data controller. Then, once
actual drag gesture started it would crash trying to access to it.

Bug-AGL: SPEC-4288
Signed-off-by: Jose Dapena Paz <jdapena@igalia.com>